### PR TITLE
Fix scripts in package.json to work on Windows

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "dev": "nodemon",
     "build": "npm run generate && tsc --noEmit && ./scripts/build.js",
     "start": "node lib/index.js",
-    "generate": "tsoa spec-and-routes && ./scripts/formatSpec.js",
+    "generate": "tsoa spec-and-routes && node ./scripts/formatSpec.js", 
     "docker:build": "docker build -t e2b/chatgpt-plugin-api .",
     "docker:start": "docker run --init -p 3000:3000 e2b/chatgpt-plugin-api"
   }


### PR DESCRIPTION
On Windows getting error message '.' is not recognized as an internal or external command, operable program or batch file. indicates that the command following the . is not recognized.
This is a common issue on Windows systems, which may not recognize the Unix-style command to run a JavaScript file (./file.js).

Solution:
modify the generate script in package.json